### PR TITLE
fix: respect run.command/args config in synf.toml

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -106,7 +106,10 @@ impl Runner {
             }
         }
 
-        let (run_command, run_args) = Self::get_run_command(&self.language);
+        // Use the configured run command and args from the instance
+        // instead of getting the default values again
+        let run_command = self.run_command.clone();
+        let run_args = self.run_args.clone();
 
         if let Some(stopped_tx) = &mut self.process_stopped_sender {
             eprintln!("Sending stop to tx");
@@ -116,8 +119,6 @@ impl Runner {
         if let Some(process) = &mut self.process {
             Self::stop(process);
         }
-
-        let run_args = run_args.clone();
 
         eprintln!("Running run command: {:?} {:?}", run_command, run_args);
         let process = std::process::Command::new(run_command)


### PR DESCRIPTION
This project has a bug. When synf.toml has the run.command/args config set, e.g., as in

[run]
# command and args are used to specify the command to run the server
# during development after it has been rebuilt
# These are the default values for python:
command = "/Users/ezyang/Dev/codemcp-prod/.venv/bin/python"
args = ["-m", "codemcp"]

This config is not respected and we run the default uv run anyway. Diagnose the problem and fix it. NB: codemcp.toml is NOT related, don't look at it.

```git-revs
ec75a0e  (Base revision)
b46a8c1  Fix the bug to respect run.command/args from synf.toml configuration
HEAD     Remove redundant clone of run_args
```

codemcp-id: 2-fix-respect-run-command-args-config-in-synf-toml
